### PR TITLE
Removed hook_menu_toggle

### DIFF
--- a/template.php
+++ b/template.php
@@ -51,17 +51,6 @@ function axioma_preprocess_header(&$variables) {
 }
 
 /**
- * Implements hook_menu_toggle().
- * Removes 'Menu' text near 'hamburger' button.
- */
-function axioma_menu_toggle(&$variables) {
-  if (isset($variables['text'])) {
-    $variables['text'] = '';
-  }
-  return theme_menu_toggle($variables);
-}
-
-/**
  * Implements hook_preprocess_block().
  * Sets alignment for system provided menu blocks.
  */


### PR DESCRIPTION
Removed code that was clearing "Menu" text near hamburger button. This should help with mobile menu disappearing #9 . This is a quick solution to make menu work. More thorough solution should implement [configurable menu text](https://github.com/backdrop/backdrop-issues/issues/6264).